### PR TITLE
Before after migrate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ services:
   - mysql
 
 install:
+  - sudo rm /etc/apt/sources.list.d/mongodb*.list
   - pip install flake8==3.3.0
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - sudo rm /etc/apt/sources.list.d/docker.list

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -14,7 +14,7 @@ import os, sys, importlib, inspect, json
 from .exceptions import *
 from .utils.jinja import get_jenv, get_template, render_template, get_email_from_template
 
-__version__ = '10.0.8'
+__version__ = '10.0.9'
 __title__ = "Frappe Framework"
 
 local = Local()
@@ -1250,7 +1250,7 @@ def get_print(doctype=None, name=None, print_format=None, style=None, html=None,
 	else:
 		return html
 
-def attach_print(doctype, name, file_name=None, print_format=None, style=None, html=None, doc=None):
+def attach_print(doctype, name, file_name=None, print_format=None, style=None, html=None, doc=None, lang=None):
 	from frappe.utils import scrub_urls
 
 	if not file_name: file_name = name
@@ -1258,6 +1258,10 @@ def attach_print(doctype, name, file_name=None, print_format=None, style=None, h
 
 	print_settings = db.get_singles_dict("Print Settings")
 
+	_lang = local.lang
+
+	#set lang as specified in print format attachment
+	if lang: local.lang = lang
 	local.flags.ignore_print_permissions = True
 
 	if int(print_settings.send_print_as_pdf or 0):
@@ -1272,6 +1276,8 @@ def attach_print(doctype, name, file_name=None, print_format=None, style=None, h
 		}
 
 	local.flags.ignore_print_permissions = False
+	#reset lang to original local lang
+	local.lang = _lang
 
 	return out
 

--- a/frappe/chat/doctype/chat_room/chat_room.py
+++ b/frappe/chat/doctype/chat_room/chat_room.py
@@ -134,8 +134,7 @@ def get(user, rooms = None, fields = None, filters = None):
 		],
 		filters  = const,
 		fields   = param + ['name'] if param else default,
-		distinct = True,
-		debug    = bool(frappe.conf.get('developer_mode'))
+		distinct = True
 	)
 
 	if not fields or 'users' in fields:

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -110,7 +110,7 @@ class File(NestedSet):
 		"""Returns folder size for current folder"""
 		if not folder:
 			folder = self.name
-		file_size =  frappe.db.sql("""select sum(ifnull(file_size,0))
+		file_size =  frappe.db.sql("""select ifnull(sum(file_size), 0)
 			from tabFile where folder=%s """, (folder))[0][0]
 
 		return file_size

--- a/frappe/docs/user/en/tutorial/before.md
+++ b/frappe/docs/user/en/tutorial/before.md
@@ -50,6 +50,7 @@ Resources:
 
  1. [Codecademy Tutorial for JavaScript](https://www.codecademy.com/learn/learn-javascript)
  1. [Codecademy Tutorial for jQuery](https://www.codecademy.com/learn/jquery)
+
 ---
 
 #### 5. Jinja Templating

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -168,6 +168,7 @@ def get_email_queue(recipients, sender, subject, **kwargs):
 			if att.get('fid'):
 				_attachments.append(att)
 			elif att.get("print_format_attachment") == 1:
+				att['lang'] = frappe.local.lang
 				_attachments.append(att)
 		e.attachments = json.dumps(_attachments)
 

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -19,13 +19,21 @@ import frappe.utils.help
 def migrate(verbose=True, rebuild_website=False):
 	'''Migrate all apps to the latest version, will:
 
+	- run before migrate hooks
 	- run patches
 	- sync doctypes (schema)
 	- sync fixtures
 	- sync desktop icons
-	- sync web pages (from /www)'''
+	- sync web pages (from /www)
+	- run after migrate hooks
+	'''
 	frappe.flags.in_migrate = True
 	clear_global_cache()
+
+	#run before_migrate hooks
+	for app in frappe.get_installed_apps():
+		for fn in frappe.get_hooks('before_migrate', app_name=app):
+			frappe.get_attr(fn)()
 
 	# run patches
 	frappe.modules.patch_handler.run_all()
@@ -44,6 +52,11 @@ def migrate(verbose=True, rebuild_website=False):
 
 	# add static pages to global search
 	router.sync_global_search()
+
+	#run after_migrate hooks
+	for app in frappe.get_installed_apps():
+		for fn in frappe.get_hooks('after_migrate', app_name=app):
+			frappe.get_attr(fn)()
 
 	frappe.db.commit()
 

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -199,11 +199,14 @@ def _set_amended_name(doc):
 
 def append_number_if_name_exists(doctype, name, fieldname='name', separator='-'):
 	if frappe.db.exists(doctype, name):
+		# should be escaped 2 times since
+		# python string will parse the first escape
+		escaped_name = re.escape(re.escape(name))
 		last = frappe.db.sql("""select name from `tab{doctype}`
 			where {fieldname} regexp '^{name}{separator}[[:digit:]]+'
 			order by length({fieldname}) desc,
 				{fieldname} desc limit 1""".format(doctype=doctype,
-					name=name, fieldname=fieldname, separator=separator))
+					name=escaped_name, fieldname=fieldname, separator=separator))
 
 		if last:
 			count = str(cint(last[0][0].rsplit("-", 1)[1]) + 1)

--- a/frappe/patches/v10_0/refactor_social_login_keys.py
+++ b/frappe/patches/v10_0/refactor_social_login_keys.py
@@ -10,33 +10,33 @@ def execute():
 		user = frappe.get_doc("User", u.get("name"))
 		save = False
 
-		if user.fb_userid and user.fb_username:
+		if user.get("fb_userid") and user.get("fb_username"):
 			user.append("social_logins", {
 				"provider": "facebook",
-				"userid": user.fb_userid,
-				"username": user.fb_username
+				"userid": user.get("fb_userid"),
+				"username": user.get("fb_username")
 			})
 			save = True
 
-		if user.frappe_userid:
+		if user.get("frappe_userid"):
 			user.append("social_logins", {
 				"provider": "frappe",
-				"userid": user.frappe_userid
+				"userid": user.get("frappe_userid")
 			})
 			save = True
 
-		if user.github_userid and user.github_username:
+		if user.get("github_userid") and user.get("github_username"):
 			user.append("social_logins", {
 				"provider": "github",
-				"userid": user.github_userid,
-				"username": user.github_username,
+				"userid": user.get("github_userid"),
+				"username": user.get("github_username"),
 			})
 			save = True
 
-		if user.google_userid:
+		if user.get("google_userid"):
 			user.append("social_logins", {
 				"provider": "google",
-				"userid": user.google_userid,
+				"userid": user.get("google_userid"),
 			})
 			save = True
 
@@ -50,43 +50,43 @@ def execute():
 		return
 
 	social_login_keys = frappe.get_doc("Social Login Keys", "Social Login Keys")
-	if social_login_keys.facebook_client_id or social_login_keys.facebook_client_secret:
+	if social_login_keys.get("facebook_client_id") or social_login_keys.get("facebook_client_secret"):
 		facebook_login_key = frappe.new_doc("Social Login Key")
 		facebook_login_key.get_social_login_provider("Facebook", initialize=True)
 		facebook_login_key.social_login_provider = "Facebook"
-		facebook_login_key.client_id = social_login_keys.facebook_client_id
-		facebook_login_key.client_secret = social_login_keys.facebook_client_secret
+		facebook_login_key.client_id = social_login_keys.get("facebook_client_id")
+		facebook_login_key.client_secret = social_login_keys.get("facebook_client_secret")
 		if not (facebook_login_key.client_secret and facebook_login_key.client_id):
 			facebook_login_key.enable_social_login = 0
 		facebook_login_key.save()
 
-	if social_login_keys.frappe_server_url:
+	if social_login_keys.get("frappe_server_url"):
 		frappe_login_key = frappe.new_doc("Social Login Key")
 		frappe_login_key.get_social_login_provider("Frappe", initialize=True)
 		frappe_login_key.social_login_provider = "Frappe"
-		frappe_login_key.base_url = social_login_keys.frappe_server_url
-		frappe_login_key.client_id = social_login_keys.frappe_client_id
-		frappe_login_key.client_secret = social_login_keys.frappe_client_secret
+		frappe_login_key.base_url = social_login_keys.get("frappe_server_url")
+		frappe_login_key.client_id = social_login_keys.get("frappe_client_id")
+		frappe_login_key.client_secret = social_login_keys.get("frappe_client_secret")
 		if not (frappe_login_key.client_secret and frappe_login_key.client_id and frappe_login_key.base_url):
 			frappe_login_key.enable_social_login = 0
 		frappe_login_key.save()
 
-	if social_login_keys.github_client_id or social_login_keys.github_client_secret:
+	if social_login_keys.get("github_client_id") or social_login_keys.get("github_client_secret"):
 		github_login_key = frappe.new_doc("Social Login Key")
 		github_login_key.get_social_login_provider("GitHub", initialize=True)
 		github_login_key.social_login_provider = "GitHub"
-		github_login_key.client_id = social_login_keys.github_client_id
-		github_login_key.client_secret = social_login_keys.github_client_secret
+		github_login_key.client_id = social_login_keys.get("github_client_id")
+		github_login_key.client_secret = social_login_keys.get("github_client_secret")
 		if not (github_login_key.client_secret and github_login_key.client_id):
 			github_login_key.enable_social_login = 0
 		github_login_key.save()
 
-	if social_login_keys.google_client_id or social_login_keys.google_client_secret:
+	if social_login_keys.get("google_client_id") or social_login_keys.get("google_client_secret"):
 		google_login_key = frappe.new_doc("Social Login Key")
 		google_login_key.get_social_login_provider("Google", initialize=True)
 		google_login_key.social_login_provider = "Google"
-		google_login_key.client_id = social_login_keys.google_client_id
-		google_login_key.client_secret = social_login_keys.google_client_secret
+		google_login_key.client_id = social_login_keys.get("google_client_id")
+		google_login_key.client_secret = social_login_keys.get("google_client_secret")
 		if not (google_login_key.client_secret and google_login_key.client_id):
 			google_login_key.enable_social_login = 0
 		google_login_key.save()

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -508,7 +508,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	get_form_link(doc) {
-		return '#Form/' + this.doctype + '/' + doc.name;
+		const docname = doc.name.match(/[%'"]/)
+			? encodeURIComponent(doc.name)
+			: doc.name;
+
+		return '#Form/' + this.doctype + '/' + docname;
 	}
 
 	get_subject_html(doc) {

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -67,10 +67,10 @@ frappe.route = function() {
 
 frappe.get_route = function(route) {
 	// for app
-	var route = frappe.get_raw_route_str(route).split('/');
+	route = frappe.get_raw_route_str(route).split('/');
 	route = $.map(route, frappe._decode_str);
 	var parts = route[route.length - 1].split("?");
-	route[route.length - 1] = frappe._decode_str(parts[0]);
+	route[route.length - 1] = parts[0];
 	if (parts.length > 1) {
 		var query_params = get_query_params(parts[1]);
 		frappe.route_options = $.extend(frappe.route_options || {}, query_params);
@@ -133,8 +133,11 @@ frappe.set_route = function() {
 				frappe.route_options = a;
 				return null;
 			} else {
+				if (a.match(/[%'"]/)) {
+					// if special chars, then encode
+					a = encodeURIComponent(a);
+				}
 				return a;
-				// return a ? encodeURIComponent(a) : null;
 			}
 		}).join('/');
 

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -131,16 +131,14 @@ frappe.ui.Tree = class {
 	}
 
 	render_node_children(node, data_set) {
-		if(node.$ul.is(':empty')) {
-			node.$ul.empty();
-			if (data_set) {
-				$.each(data_set, (i, data) => {
-					var child_node = this.add_node(node, data);
-					child_node.$tree_link
-						.data('node-data', data)
-						.data('node', child_node);
-				});
-			}
+		node.$ul.empty();
+		if (data_set) {
+			$.each(data_set, (i, data) => {
+				var child_node = this.add_node(node, data);
+				child_node.$tree_link
+					.data('node-data', data)
+					.data('node', child_node);
+			});
 		}
 
 		node.expanded = false;
@@ -245,7 +243,10 @@ frappe.ui.Tree = class {
 				.html(label)
 				.addClass('tree-toolbar-button ' + (obj.btnClass || ''))
 				.appendTo($toolbar);
-			$link.on('click', () => { obj.click(node); return false; });
+			$link.on('click', () => {
+				obj.click(node);
+				this.refresh();
+			});
 		});
 
 		return $toolbar;

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -273,7 +273,7 @@ frappe.views.CommunicationComposer = Class.extend({
 		this.lang_code = doc.language
 
 		//On selection of language retrieve language code
-		$(fields.language_sel.input).click(function(){
+		$(fields.language_sel.input).change(function(){
 			me.lang_code = this.value
 		})
 

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -226,7 +226,7 @@ frappe.views.TreeView = Class.extend({
 				},
 				click: function(node) {
 					frappe.model.rename_doc(me.doctype, node.label, function(new_name) {
-						node.tree_link.find('a').text(new_name);
+						node.$tree_link.find('a').text(new_name);
 						node.label = new_name;
 					});
 				},

--- a/frappe/utils/selenium_testdriver.py
+++ b/frappe/utils/selenium_testdriver.py
@@ -38,7 +38,7 @@ class TestDriver(object):
 		self.driver = webdriver.Chrome(chrome_options=chrome_options,
 			desired_capabilities=capabilities, port=9515)
 
-		self.driver.set_window_size(1080,800)
+		# self.driver.set_window_size(1080,800)
 		self.cur_route = None
 		self.logged_in = False
 


### PR DESCRIPTION
There can often be a requirement to run some app specific functions before and after bench migrate command. This pull request adds code for configuring following hooks
```
before_migrate: [
 "{dotted.path.to.function1}",
 "{dotted.path.to.function2}",..
]

after_migrate: [
 "{dotted.path.to.function1}",
 "{dotted.path.to.function2}",..
]
```